### PR TITLE
allow for emojis

### DIFF
--- a/script.py
+++ b/script.py
@@ -66,8 +66,11 @@ def write_config():
         json.dump(params, f, indent=4)
 
 def write_log(char, s):
-    with open(LOG_DIR+char+LOG_FILE, 'a') as f:
-        f.write(s)
+    try:
+        with open(LOG_DIR+char+LOG_FILE, 'a', encoding='utf-8') as f:
+            f.write(s)
+    except Exception as e:
+        print(f"Error writing to log: {e}")
 
 config = []
 try:


### PR DESCRIPTION
there were errors with some chat models that would reply with an emoji, this seems to fix that. 

this was error before asking for an emoji or if the charactor just always replied with one 

File "C:\oobabooga\oobabooga_windows\text-generation-webui\extensions\Autobooga\script.py", line 336, in output_modifier
    write_log(character, "("+now+")"+character+"> "+llm_response+"\n")
  File "C:\oobabooga\oobabooga_windows\text-generation-webui\extensions\Autobooga\script.py", line 70, in write_log
    f.write(s)
  File "C:\oobabooga\oobabooga_windows\installer_files\env\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f436' in position 122: character maps to <undefined>

