### PR TITLE
Parse webpage through readability lxml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 requests
 beautifulsoup4
+readability-lxml
+lxml
 summarizer
 datetime
 PyPDF2


### PR DESCRIPTION
I modified the get_page function to use Readability which  based on the same functionality employed by web browsers like Firefox which provide a ReaderView option for web pages. I've found this yields improved results with less hallucination when extracting and presenting web page content to text-generation.